### PR TITLE
Use "env python3" instead of "python3"

### DIFF
--- a/telegramTUI
+++ b/telegramTUI
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from src.ui import App
 
 TelegeramTUI = App()


### PR DESCRIPTION
I think using `/usr/bin/env python3` would be much better than the current `/usr/bin/python3`. Especially when you are in a virtual environment, you can be sure to use a separate environment.